### PR TITLE
Finished v7 release preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Introduction 
-Remote control one or many virtual machine(s) on a (remote) Hyper-V Server. 
+Remote control one or many virtual machine(s) on a (remote) Hyper-V Server (without SCVMM). 
 The Azure Pipelines task supports start and stop a virtual machine plus create, restore and delete Hyper-V snapshots. 
 
 # Getting Started

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -61,12 +61,12 @@ jobs:
         Remove-Item -Path $from -Recurse -Force
       displayName: 'Add VstsTaskSdk PowerShell SDK'
 
-    - task: ToreGroneng.ToreGroneng-PSScriptAnalyzer-Task.PSScriptAnalyzer-Task.PowerShell Script Analyzer@1
-      displayName: 'Execute PsScriptAnalyzer '
-      inputs:
-          PsFolder: src/HyperVServer/HyperVServer
-          ExcludeRules: 'PSAvoidUsingWriteHost'
-          Severity: 'Error,Warning'
+      #- task: ToreGroneng.ToreGroneng-PSScriptAnalyzer-Task.PSScriptAnalyzer-Task.PowerShell Script Analyzer@1
+      #  displayName: 'Execute PsScriptAnalyzer '
+      #  inputs:
+      #      PsFolder: src/HyperVServer/HyperVServer
+      #      ExcludeRules: 'PSAvoidUsingWriteHost'
+      #      Severity: 'Error,Warning'
 
     - task: ms-devlabs.vsts-developer-tools-build-tasks.package-extension-build-task.PackageVSTSExtension@1
       displayName: 'Package Extension: AIT BuildSuite HyperV for Azure DevOps / Visual Studio Marketplace based deployment'

--- a/src/HyperVServer/HyperVServer/HyperVServer.ps1
+++ b/src/HyperVServer/HyperVServer/HyperVServer.ps1
@@ -586,6 +586,10 @@ function Stop-VMByTurningOffVM
 					write-debug "Current VM $vmname status: $($vm.Status)"
 					Write-Host "VM $vmname on $hostname is now turned off."
 				}
+				else 
+				{
+					Write-Host "VM $($vm.Name) is already turned off."
+				}
 			}			
 		}
         <# Post-impact code #>

--- a/src/HyperVServer/HyperVServer/HyperVServer.ps1
+++ b/src/HyperVServer/HyperVServer/HyperVServer.ps1
@@ -343,12 +343,14 @@ function Get-ApplicationsHealthyStatusOfStartHyperVVM
 				Start-Sleep -Seconds 5
 				write-host "Checking status again in 5 sec."
 				$vm = Get-VM -Name $vmname -Computername $hostname
+				$heartbeatTimeout = $appHealthyHeartbeatTimeout;
 
 				if ($null -eq $heartbeatTimeout -or $heartbeatTimeout -eq 0)
 				{
-					Write-Verbose "Assigning default value to heartbeat timeout $heartbeatTimeout";
+					Write-Verbose "Assigning default value to heartbeat timeout because it is $heartbeatTimeout";
 					# If the Heartbeat Timeout is set we stay at the default of 5 minutes.
 					$heartbeatTimeout = 5*60;
+					Write-Host "Default heartbeat timeout is $heartbeatTimeout";
 				}	
 				else 
 				{
@@ -1106,8 +1108,8 @@ Try
 	[int]$timeBasedStatusWaitInterval = Get-VstsInput -Name StartVMWaitTimeBasedCheckInterval
 	[string]$ConfirmPreference="None"
 
-	[int]$heartbeatTimeout = Get-VstsTaskVariable -Name HyperV.HeartbeatTimeout
-	[int]$waitingTimeNumberOfStatusNotifications = Get-VstsTaskVariable -Name HyperV.WaitingNumberOfStatusNotifications
+	[int]$appHealthyHeartbeatTimeout = Get-VstsTaskVariable -Name HyperV.HyperV.StartVMAppHealthyHeartbeatTimeout
+	[int]$waitingTimeNumberOfStatusNotifications = Get-VstsTaskVariable -Name HyperV.StartVMWaitingNumberOfStatusNotifications
 
 	Get-HyperVCmdletsAvailable
 	Get-ParameterOverview

--- a/src/HyperVServer/HyperVServer/HyperVServer.ps1
+++ b/src/HyperVServer/HyperVServer/HyperVServer.ps1
@@ -569,28 +569,24 @@ function Stop-VMByTurningOffVM
             Write-Verbose ('[{0}] Reached command' -f $MyInvocation.MyCommand)
             # Variable scope ensures that parent session remains unchanged
             $ConfirmPreference = 'None'
-
-			$workInProgress = $true;
-			while ($workInProgress)
+			
+			for ($i=0;$i -lt $vmnames.Count; $i++)
 			{
-				for ($i=0;$i -lt $vmnames.Count; $i++)
+				$vmname = $vmnames[$i];
+				$vm = Get-VM -Name $vmname -Computername $hostname
+				if ($vm.State -ne "Off")
 				{
-					$vmname = $vmnames[$i];
-					$vm = Get-VM -Name $vmname -Computername $hostname
-					if ($vm.State -ne "Off")
-					{
-						write-host "Direct turning off the VM $vmname (no regular gracefull shutdown)."
-						write-debug "Current VM $vmname state: $($vm.State)"
-						write-debug "Current VM $vmname status: $($vm.Status)"
+					write-host "Direct turning off the VM $vmname (no regular gracefull shutdown)."
+					write-debug "Current VM $vmname state: $($vm.State)"
+					write-debug "Current VM $vmname status: $($vm.Status)"
 
-						Stop-VM -Name $vmname -ComputerName $hostname -TurnOff -Force -ErrorAction SilentlyContinue
-						Start-Sleep -Seconds 5
-						write-debug "Current VM $vmname state: $($vm.State)"
-						write-debug "Current VM $vmname status: $($vm.Status)"
-						Write-Host "VM $vmname on $hostname is now turned off."
-					}
+					Stop-VM -Name $vmname -ComputerName $hostname -TurnOff -Force -ErrorAction SilentlyContinue
+					Start-Sleep -Seconds 5
+					write-debug "Current VM $vmname state: $($vm.State)"
+					write-debug "Current VM $vmname status: $($vm.Status)"
+					Write-Host "VM $vmname on $hostname is now turned off."
 				}
-			}
+			}			
 		}
         <# Post-impact code #>
     }

--- a/src/HyperVServer/HyperVServer/HyperVServer.ps1
+++ b/src/HyperVServer/HyperVServer/HyperVServer.ps1
@@ -573,7 +573,7 @@ function Stop-VMByTurningOffVM
 			$workInProgress = $true;
 			while ($workInProgress)
 			{
-				for ($i=0; $vmnames.Count; $i++)
+				for ($i=0;$i -lt $vmnames.Count; $i++)
 				{
 					$vmname = $vmnames[$i];
 					$vm = Get-VM -Name $vmname -Computername $hostname
@@ -758,7 +758,7 @@ function Start-TurnOfVM {
             # Variable scope ensures that parent session remains unchanged
             $ConfirmPreference = 'None'
 
-			Stop-VMByTurningOffVM -vmnames $vmnames -hostname $hostname
+			Stop-VMByTurningOffVM -vmnames $vmnames -hostname $hostname -Confirm:$false
 		}
 	
         <# Post-impact code #>

--- a/src/HyperVServer/HyperVServer/HyperVServer.ps1
+++ b/src/HyperVServer/HyperVServer/HyperVServer.ps1
@@ -1110,6 +1110,16 @@ Try
 
 	[int]$appHealthyHeartbeatTimeout = Get-VstsTaskVariable -Name HyperV.HyperV.StartVMAppHealthyHeartbeatTimeout
 	[int]$waitingTimeNumberOfStatusNotifications = Get-VstsTaskVariable -Name HyperV.StartVMWaitingNumberOfStatusNotifications
+	[string]$hyperVPsModuleVersion = Get-VstsTaskVariable -Name HyperV.PsModuleVersion
+
+	if (![string]::IsNullOrEmpty($hyperVPsModuleVersion))
+	{
+		Write-Host "Loading Hyper-V PowerShell module version $hyperVPsModuleVersion";
+		Import-Module –Name Hyper-V -Version $hyperVPsModuleVersion;
+	}
+	else {
+		Write-Host "Loading Hyper-V system default PowerShell module"
+	}
 
 	Get-HyperVCmdletsAvailable
 	Get-ParameterOverview

--- a/src/HyperVServer/HyperVServer/task.json
+++ b/src/HyperVServer/HyperVServer/task.json
@@ -19,7 +19,7 @@
       "name": "Action",
       "type": "pickList",
       "label": "Action",
-      "defaultValue": "Start VM",
+      "defaultValue": "StartVM",
       "required": true,
       "helpMarkDown": "The action that will be performed on the Hyper-V VM(s).",
       "options": {

--- a/src/HyperVServer/HyperVServer/task.json
+++ b/src/HyperVServer/HyperVServer/task.json
@@ -3,8 +3,8 @@
   "name": "HyperVServer",
   "friendlyName": "Hyper-V Server",
   "author": "AIT Gmbh & Co. KG",
-  "description": "Remote control Hyper-V VMs and perform actions like start and stop VM, create or restore a snapshot",
-  "helpMarkDown": "This step supports remote control of Hyper-V VMs and servers. It supports starting and stopping a VM plus creating, restoring or deleting a VM snapshot.",
+  "description": "Remote control Hyper-V VMs and perform actions like start and stop VM, create or restore a snapshot (without SCVMM)",
+  "helpMarkDown": "This step supports remote control of Hyper-V VMs and servers (without SCVMM). It supports starting and stopping a VM plus creating, restoring or deleting a VM snapshot.",
   "category": "Deploy",
   "version": {
     "Major": 0,
@@ -24,7 +24,8 @@
       "helpMarkDown": "The action that will be performed on the Hyper-V VM(s).",
       "options": {
         "StartVM":"Start VM",
-        "StopVM":"Stop VM",
+        "ShutdownVM":"Shutdown VM",
+        "TurnOffVM":"Turn off VM",
         "CreateSnapshot":"Create Snapshot",
         "RestoreSnapshot":"Restore Snapshot",
         "RemoveSnapshot":"Remove Snapshot"

--- a/src/HyperVServer/Readme.md
+++ b/src/HyperVServer/Readme.md
@@ -1,6 +1,6 @@
 # Hyper-V Server task
 
-Remote control a virtual machine on a (remote) Hyper-V Server. The Azure Pipelines task supports start and stop a virtual machine plus create, restore and delete Hyper-V snapshots. 
+Remote control a virtual machine on a (remote) Hyper-V Server. The Azure Pipelines task supports start and stop a virtual machine plus create, restore and delete Hyper-V snapshots (without SCVMM). 
 
 ### Requirements
 -------
@@ -22,7 +22,7 @@ and [Hyper-V Module](https://technet.microsoft.com/itpro/powershell/windows/hype
 * Changes since 6.0.0: Added support for multiple VMs names in one build step, added support for deleting snapshots, code refactoring and cleanup
 * Changes since 6.0.8: Added information about data protection
 * Changes since 6.1.0: Adapted Azure DevOps rebranding in certain files/places, opensourced version on GitHub
-* Changes since 7.0.0: Moved vom Powershell to Powershell3 execution handler, refactored code based on PSScriptAnalyzer
+* Changes since 7.0.0: Moved from Powershell to Powershell3 execution handler, added direct turn off of VMs, renamed action StopVM to ShutdownVM, fixed bug in vmeventing (missing parameter), refactored code based on PSScriptAnalyzer
 
 ### Known limitions
 -------

--- a/src/HyperVServer/vss-extension.json
+++ b/src/HyperVServer/vss-extension.json
@@ -8,7 +8,7 @@
   "targets": [{
     "id": "Microsoft.VisualStudio.Services"
   }],
-  "description": "Remote control Hyper-V VMs and perform actions like start and stop VM, create or restore a snapshot",
+  "description": "Remote control Hyper-V VMs and perform actions like start and stop VM, create or restore a snapshot (without SCVMM)",
   "repository": {
     "type": "git",
     "uri": "https://github.com/AITGmbH/AIT.BuildSuite.HyperV"

--- a/src/HyperVServer/vss-extension.json
+++ b/src/HyperVServer/vss-extension.json
@@ -22,13 +22,21 @@
     }
   },
   "links": {
+    "getstarted": {
+      "uri": "https://github.com/AITGmbH/AIT.BuildSuite.HyperV/wiki"
+    },
     "support": {
-      "uri": "https://www.aitgmbh.de/kontakt-und-anfahrt/"
+      "uri": "https://github.com/AITGmbH/AIT.BuildSuite.HyperV/issues"
     },
     "privacypolicy": {
       "uri": "https://www.aitgmbh.de/datenschutz"
     },
-    "screenshots": [{
+    "license": {
+      "uri": "https://github.com/AITGmbH/AIT.BuildSuite.HyperV/blob/master/LICENSE"
+    }
+  },
+  "screenshots": [
+      {
         "path": "HyperVServerConfiguration.png"
       },
       {
@@ -37,13 +45,21 @@
       {
         "path": "HyperVServerResult.png"
       }
-    ]
-  },
+    ],
   "categories": [
     "__ExtensionCategory__"
   ],
   "tags": [
-    "Deploy task, HyperV, Release Management, VM, Virtual Machine, SCVMM, Windows Server, AIT BuildSuite"
+    "Deploy task", 
+    "HyperV",
+    "Hyper-V", 
+    "Release Management", 
+    "VM", 
+    "Virtual Machine", 
+    "SCVMM",
+    "System Center Virtual Machine Manager",
+    "Windows Server", 
+    "AIT BuildSuite"
   ],
   "icons": {
     "default": "extension-icon.png"


### PR DESCRIPTION
- fixed bugs in new status checks for VM starts, kill work process disabled (stopvm) because this led to a VM restart (we ended the vm too unfriendly too early)
- implemented some additional task variables (starting with hyperv.*) to adjust the runtime behaviour (details see wiki -> only for powerusers)
- loading of older powershell module versions, so that the task is compatible with older hyper-v versions
- updated task readme
- fixed erros in task and extension manifest files
- several small bugfixes and code cleanups in different places