### PR TITLE
Bugfix for HyperV cmdlet version 1.0 - computername not available

### DIFF
--- a/src/HyperVServer/HyperVServer/HyperVServer.ps1
+++ b/src/HyperVServer/HyperVServer/HyperVServer.ps1
@@ -79,7 +79,14 @@ function Set-HyperVCmdletCacheDisabled
             $ConfirmPreference = 'None'
 
 			write-host "Disable Hyper-V cmdlet caching."
-			Disable-VMEventing -ComputerName $Computername -force
+			if ($hyperVPsModuleVersion -eq "1.0")
+			{
+				Disable-VMEventing -force
+			} 
+			else 
+			{
+				Disable-VMEventing -ComputerName $Computername -force
+			}		
 		}
 	}
 
@@ -125,9 +132,15 @@ function Set-HyperVCmdletCacheEnabled
             $ConfirmPreference = 'None'
 
 			write-host "(Re-)Enable Hyper-V cmdlet caching."
-			Enable-VMEventing -ComputerName $Computername -force
+			if ($hyperVPsModuleVersion -eq "1.0")
+			{
+				Enable-VMEventing -force
+			}
+			else 
+			{
+				Enable-VMEventing -ComputerName $Computername -force
+			}
 		}
-
 	}
 
     End {

--- a/src/HyperVServer/Readme.md
+++ b/src/HyperVServer/Readme.md
@@ -23,6 +23,7 @@ and [Hyper-V Module](https://technet.microsoft.com/itpro/powershell/windows/hype
 * Changes since 6.0.8: Added information about data protection
 * Changes since 6.1.0: Adapted Azure DevOps rebranding in certain files/places, opensourced version on GitHub
 * Changes since 7.0.0: Moved from Powershell to Powershell3 execution handler, added direct turn off of VMs, renamed action StopVM to ShutdownVM, fixed bug in vmeventing (missing parameter), refactored code based on PSScriptAnalyzer
+* Changes since 7.0.36: Removed non-existent parameter for hyperv cmdlet version 1.0 (only affects old hyper-v versions)
 
 ### Known limitions
 -------


### PR DESCRIPTION
The parameter computer name is not available in commands enable-vmeventing and disable-vmeventing