### PR TITLE
Hyper-V cmdlet v.1.1 support

### DIFF
--- a/src/HyperVServer/HyperVServer/HyperVServer.ps1
+++ b/src/HyperVServer/HyperVServer/HyperVServer.ps1
@@ -79,7 +79,7 @@ function Set-HyperVCmdletCacheDisabled
             $ConfirmPreference = 'None'
 
 			write-host "Disable Hyper-V cmdlet caching."
-			if ($hyperVPsModuleVersion -eq "1.0")
+			if ($hyperVPsModuleVersion -eq "1.0" -or $hyperVPsModuleVersion -eq "1.1")
 			{
 				Disable-VMEventing -force
 			} 
@@ -132,7 +132,7 @@ function Set-HyperVCmdletCacheEnabled
             $ConfirmPreference = 'None'
 
 			write-host "(Re-)Enable Hyper-V cmdlet caching."
-			if ($hyperVPsModuleVersion -eq "1.0")
+			if ($hyperVPsModuleVersion -eq "1.0" -or $hyperVPsModuleVersion -eq "1.1")
 			{
 				Enable-VMEventing -force
 			}

--- a/src/HyperVServer/Readme.md
+++ b/src/HyperVServer/Readme.md
@@ -23,7 +23,8 @@ and [Hyper-V Module](https://technet.microsoft.com/itpro/powershell/windows/hype
 * Changes since 6.0.8: Added information about data protection
 * Changes since 6.1.0: Adapted Azure DevOps rebranding in certain files/places, opensourced version on GitHub
 * Changes since 7.0.0: Moved from Powershell to Powershell3 execution handler, added direct turn off of VMs, renamed action StopVM to ShutdownVM, fixed bug in vmeventing (missing parameter), refactored code based on PSScriptAnalyzer
-* Changes since 7.0.36: Removed non-existent parameter for hyperv cmdlet version 1.0 (only affects old hyper-v versions)
+* Changes since 7.0.36: Removed non-existent parameter for hyperv cmdlet version 1.0 (only affects old hyper-v versions -> pre Win 2016)
+* Changes since 7.0.62: Added additional support for older hyperv cmdlet version 1.1 (only affects old hyper-v versions -> pre Win 2016)
 
 ### Known limitions
 -------


### PR DESCRIPTION
Support for control of older hyper-v servers on new windows versions (use of hyper-v cmdlet version 1.1 on e.g. Win 10 or Windows Server 2019)