### PR TITLE
Bugfix - Loading older cmdlet versions

### DIFF
--- a/src/HyperVServer/HyperVServer/HyperVServer.ps1
+++ b/src/HyperVServer/HyperVServer/HyperVServer.ps1
@@ -1127,8 +1127,16 @@ Try
 
 	if (![string]::IsNullOrEmpty($hyperVPsModuleVersion))
 	{
+		# in case something it not working as expected we want to know which modules are available
+		$availableModules = Get-Module hyper-v -ListAvailable
+		Write-Debug ($availableModules | Format-Table | Out-String)
+
 		Write-Host "Loading Hyper-V PowerShell module version $hyperVPsModuleVersion";
-		Import-Module –Name Hyper-V -Version $hyperVPsModuleVersion;
+		Import-Module –Name Hyper-V -RequiredVersion $hyperVPsModuleVersion -Force -Global;
+
+		# in case something it not working as expected we want to know which modules are loaded
+		$checkLoadedModules = Get-Module hyper-v
+		Write-Debug ($checkLoadedModules | Format-Table | Out-String)
 	}
 	else {
 		Write-Host "Loading Hyper-V system default PowerShell module"

--- a/src/HyperVServer/HyperVServer/HyperVServer.ps1
+++ b/src/HyperVServer/HyperVServer/HyperVServer.ps1
@@ -79,7 +79,7 @@ function Set-HyperVCmdletCacheDisabled
             $ConfirmPreference = 'None'
 
 			write-host "Disable Hyper-V cmdlet caching."
-			if ($hyperVPsModuleVersion -eq "1.0")
+			if ($hyperVPsModuleVersion -eq "1.0" -or $hyperVPsModuleVersion -eq "1.1")
 			{
 				Disable-VMEventing -force
 			} 
@@ -132,7 +132,7 @@ function Set-HyperVCmdletCacheEnabled
             $ConfirmPreference = 'None'
 
 			write-host "(Re-)Enable Hyper-V cmdlet caching."
-			if ($hyperVPsModuleVersion -eq "1.0")
+			if ($hyperVPsModuleVersion -eq "1.0" -or $hyperVPsModuleVersion -eq "1.1")
 			{
 				Enable-VMEventing -force
 			}

--- a/src/HyperVServer/Readme.md
+++ b/src/HyperVServer/Readme.md
@@ -24,6 +24,7 @@ and [Hyper-V Module](https://technet.microsoft.com/itpro/powershell/windows/hype
 * Changes since 6.1.0: Adapted Azure DevOps rebranding in certain files/places, opensourced version on GitHub
 * Changes since 7.0.0: Moved from Powershell to Powershell3 execution handler, added direct turn off of VMs, renamed action StopVM to ShutdownVM, fixed bug in vmeventing (missing parameter), refactored code based on PSScriptAnalyzer
 * Changes since 7.0.36: Removed non-existent parameter for hyperv cmdlet version 1.0 (only affects old hyper-v versions)
+* Changes since 7.0.66: Fixed loading of older cmdlet versions, added some additional debug outputs (could be enabled with system.debug = true)
 
 ### Known limitions
 -------


### PR DESCRIPTION
Fixed loading of older cmdlet versions, added some additional debug outputs (could be enabled with system.debug = true)